### PR TITLE
修复区域等级无法识别的问题

### DIFF
--- a/renderer/public/data/zh_CN/client_strings.js
+++ b/renderer/public/data/zh_CN/client_strings.js
@@ -57,7 +57,7 @@ export default {
   QUALITY_ANOMALOUS: /^异常 (.*)$/,
   QUALITY_DIVERGENT: /^分歧 (.*)$/,
   QUALITY_PHANTASMAL: /^魅影 (.*)$/,
-  AREA_LEVEL: '地区等级: ',
+  AREA_LEVEL: '区域等级: ',
   HEIST_WINGS_REVEALED: '发现的侧厅: ',
   HEIST_TARGET: '赏金目标：',
   HEIST_BLUEPRINT_ENCHANTS: '附魔军备',


### PR DESCRIPTION
自测蓝图, 阿佐亚特编年史, 炸坟日志, 禁域典籍都能正常识别区域等级