### PR TITLE
优化触发聊天快捷键时会多次输入回车的问题

### DIFF
--- a/ipc/types.ts
+++ b/ipc/types.ts
@@ -34,6 +34,7 @@ export interface ShortcutAction {
     type: 'paste-in-chat'
     text: string
     send: boolean
+    restoreLastChat: boolean
   } | {
     type: 'test-only'
   }

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -154,7 +154,7 @@ export class Shortcuts {
           this.areaTracker.removeListeners()
           this.overlay.toggleActiveState()
         } else if (entry.action.type === 'paste-in-chat') {
-          typeInChat(entry.action.text, entry.action.send, this.clipboard)
+          typeInChat(entry.action.text, entry.action.send, entry.action.restoreLastChat, this.clipboard)
         } else if (entry.action.type === 'trigger-event') {
           this.server.sendEventTo('broadcast', {
             name: 'MAIN->CLIENT::widget-action',

--- a/main/src/shortcuts/text-box.ts
+++ b/main/src/shortcuts/text-box.ts
@@ -13,7 +13,7 @@ const AUTO_CLEAR = [
   '/' // Command
 ]
 
-export function typeInChat (text: string, send: boolean, clipboard: HostClipboard) {
+export function typeInChat (text: string, send: boolean, restoreLastChat: boolean, clipboard: HostClipboard) {
   clipboard.restoreShortly((clipboard) => {
     const modifiers = process.platform === 'darwin' ? [Key.Meta] : [Key.Ctrl]
 
@@ -42,10 +42,12 @@ export function typeInChat (text: string, send: boolean, clipboard: HostClipboar
     if (send) {
       uIOhook.keyTap(Key.Enter)
       // restore the last chat
-      uIOhook.keyTap(Key.Enter)
-      uIOhook.keyTap(Key.ArrowUp)
-      uIOhook.keyTap(Key.ArrowUp)
-      uIOhook.keyTap(Key.Escape)
+      if (restoreLastChat) {
+        uIOhook.keyTap(Key.Enter)
+        uIOhook.keyTap(Key.ArrowUp)
+        uIOhook.keyTap(Key.ArrowUp)
+        uIOhook.keyTap(Key.Escape)
+      }
     }
   })
 }

--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -284,6 +284,7 @@
     "last_char_name": "Last character name",
     "chat_cmd_add": "Add command",
     "chat_cmd_send": "press Enter",
+    "chat_restore_last_chat": "restore last chat",
     "no_key": "Not Set",
     "clear_hotkey": "You can clear hotkey by pressing Backspace",
     "overlay" :"Overlay",

--- a/renderer/public/data/ko/app_i18n.json
+++ b/renderer/public/data/ko/app_i18n.json
@@ -278,6 +278,7 @@
     "last_char_name": "마지막 캐릭터 이름",
     "chat_cmd_add": "명령어 추가",
     "chat_cmd_send": "Enter를 치세요",
+    "chat_restore_last_chat": "restore last chat",
     "no_key": "지정없음",
     "clear_hotkey": "백스페이스를 누르면 핫키가 초기화됩니다",
     "overlay": "오버레이",

--- a/renderer/public/data/ru/app_i18n.json
+++ b/renderer/public/data/ru/app_i18n.json
@@ -295,6 +295,7 @@
     "last_char_name": "Имя последнего персонажа",
     "chat_cmd_add": "Добавить команду",
     "chat_cmd_send": "нажимать Enter",
+    "chat_restore_last_chat": "restore last chat",
     "no_key": "Не назначено",
     "clear_hotkey": "Вы можете отключить сочетание, нажав клавишу Backspace",
     "overlay" :"Оверлей",

--- a/renderer/public/data/zh_CN/app_i18n.json
+++ b/renderer/public/data/zh_CN/app_i18n.json
@@ -316,6 +316,7 @@
     "last_char_name": "最近角色名称",
     "chat_cmd_add": "增加命令",
     "chat_cmd_send": "按回车(Enter)",
+    "chat_restore_last_chat": "恢复最近一条发言(会导致多次输入回车)",
     "no_key": "未设置",
     "clear_hotkey": "你可以使用Backspace(回退键)来清除快捷键",
     "overlay" :"Overlay",

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -111,6 +111,7 @@ export interface Config {
     text: string
     hotkey: string | null
     send: boolean
+    restoreLastChat: boolean
   }>
   clientLog: string | null
   gameConfig: string | null
@@ -127,7 +128,7 @@ export interface Config {
 }
 
 export const defaultConfig = (): Config => ({
-  configVersion: 16,
+  configVersion: 17,
   overlayKey: 'Shift + Space',
   overlayBackground: 'rgba(129, 139, 149, 0.15)',
   overlayBackgroundClose: true,
@@ -136,27 +137,33 @@ export const defaultConfig = (): Config => ({
   commands: [{
     text: '/hideout',
     hotkey: 'F5',
-    send: true
+    send: true,
+    restoreLastChat: true
   }, {
     text: '/exit',
     hotkey: 'F9',
-    send: true
+    send: true,
+    restoreLastChat: true
   }, {
     text: '@last ty',
     hotkey: null,
-    send: true
+    send: true,
+    restoreLastChat: true
   }, {
     text: '/invite @last',
     hotkey: null,
-    send: true
+    send: true,
+    restoreLastChat: true
   }, {
     text: '/tradewith @last',
     hotkey: null,
-    send: true
+    send: true,
+    restoreLastChat: true
   }, {
     text: '/hideout @last',
     hotkey: null,
-    send: true
+    send: true,
+    restoreLastChat: true
   }],
   clientLog: null,
   gameConfig: null,
@@ -563,6 +570,15 @@ function upgradeConfig (_config: Config): Config {
     }
   }
 
+  if (config.configVersion < 17) {
+    config.commands.forEach(command => {
+      if (command.restoreLastChat === undefined) {
+        command.restoreLastChat = true
+      }
+    })
+    config.configVersion = 17
+  }
+
   return config as unknown as Config
 }
 
@@ -632,7 +648,7 @@ function getConfigForHost (): HostConfig {
     if (command.hotkey) {
       actions.push({
         shortcut: command.hotkey,
-        action: { type: 'paste-in-chat', text: command.text, send: command.send }
+        action: { type: 'paste-in-chat', text: command.text, send: command.send, restoreLastChat: command.restoreLastChat }
       })
     }
   }

--- a/renderer/src/web/settings/chat.vue
+++ b/renderer/src/web/settings/chat.vue
@@ -8,6 +8,9 @@
           <button @click="removeCommand(idx)" class="ml-auto text-gray-500">{{ t('Remove') }}</button>
           <hotkey-input v-model="command.hotkey" class="w-48" />
         </div>
+        <div class="flex gap-x-2">
+          <ui-toggle v-model="command.restoreLastChat" class="ml-1">{{ t('settings.chat_restore_last_chat') }}</ui-toggle>
+        </div>
       </div>
     </div>
     <button @click="addComand" class="bg-gray-900 rounded flex items-baseline px-2 py-1 leading-none"><i class="fas fa-plus mr-1"></i> {{ t('settings.chat_cmd_add') }}</button>
@@ -34,7 +37,8 @@ export default defineComponent({
         props.config.commands.push({
           text: '',
           hotkey: null,
-          send: true
+          send: true,
+          restoreLastChat: true
         })
       },
       removeCommand (idx: number) {


### PR DESCRIPTION
优化触发聊天快捷键时会多次输入回车的问题. 
原因是在开启了按回车功能的情况下, 在聊天完之后会键入 回车 -> 上 -> 上 ->ESC 来恢复最近一条发言. 增加了一个开关来控制这个功能
![image](https://github.com/user-attachments/assets/a9e4822f-c735-4147-93b9-75cc98f73e96)
